### PR TITLE
Added 1 / 7 / 30 day reward averages and fixed bug that crashed when querying new hotspots

### DIFF
--- a/helium_hotspot_exporter.py
+++ b/helium_hotspot_exporter.py
@@ -193,6 +193,8 @@ def stats_for_hotspot(addr, hname):
   HOTSPOT_UP.labels(addr,hname).set(1)
 
   HOTSPOT_HEIGHT.labels(addr,hname,'system').set(d['block'])
+  if d['status']['height'] == None:
+      d['status']['height'] = 0
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_current').set(d['status']['height'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_added').set(d['block_added'])
   #HOTSPOT_HEIGHT.labels(addr,hname,'score_update').set(d[''])
@@ -210,8 +212,11 @@ def stats_for_hotspot(addr, hname):
   HOTSPOT_ONLINE.labels(addr,hname).set(isup)
 
   haz_addr = 0
-  if len(d['status']['listen_addrs']):
-    haz_addr = 1
+  try: 
+    if len(d['status']['listen_addrs']):
+      haz_addr = 1
+  except:
+     log.warn("status for hotspot %s is incomplete. Maybe this is a new hotspot"%hname)
   HOTSPOT_YES_LISTEN_ADDRS.labels(addr,hname).set(haz_addr)
 
   # other stats

--- a/helium_hotspot_exporter.py
+++ b/helium_hotspot_exporter.py
@@ -23,6 +23,7 @@ API_BASE_URL = os.environ.get('API_BASE_URL', 'https://api.helium.io/v1/')
 UPDATE_PERIOD = int(os.environ.get('UPDATE_PERIOD', 30))
 NEARBY_DISTANCE_M = int(os.environ.get('NEARBY_DISTANCE_M', 20*1000))
 
+headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
 req = requests.session()
 
 
@@ -86,7 +87,7 @@ def mkurl(*args):
 def req_get_json(url):
   try:
     log.debug(f"fetching url: {url}")
-    ret = req.get(url)
+    ret = req.get(url, headers=headers)
     log.debug(f"fetch returned: {ret}")
     if ret and ret.ok:
       return ret.json()
@@ -198,6 +199,8 @@ def stats_for_hotspot(addr, hname):
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_current').set(d['status']['height'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_added').set(d['block_added'])
   #HOTSPOT_HEIGHT.labels(addr,hname,'score_update').set(d[''])
+  if d['last_poc_challenge'] == None:
+      d['last_poc_challenge'] = 0
   HOTSPOT_HEIGHT.labels(addr,hname,'last_poc_challenge').set(d['last_poc_challenge'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_last_changed').set(d['last_change_block'])
 


### PR DESCRIPTION
I hope packing these two different changes in one pull request is not bad form. 

I added a new metric `helium_hotspot_rewards` with a `timeframe` option with the values `1d`, `7d` or `30d` that represent a hotspots earned rewards in the last 1/7/30 days. This information is acquired using the `/hotspot/:address/rewards/sum` api call (see [here](https://docs.helium.com/api/blockchain/hotspots#reward-total-for-a-hotspot)).

I also had problems with the program crashing with recently added hotspots (age < 2 days). As it seems, these hotspots don't have the fields `['status']['height']` and `['status']['listen_addrs']` populated. I added simple checks that prevent the program from crashing if either of these values is `None`
