### PR TITLE
skip some metrics for mode=dataonly hotspots

### DIFF
--- a/helium_hotspot_exporter.py
+++ b/helium_hotspot_exporter.py
@@ -178,11 +178,12 @@ def stats_for_hotspot(addr, hname):
   # this hotspot exists.
   HOTSPOT_UP.labels(addr,hname).set(1)
 
+  if d['mode'] == 'full':
+    HOTSPOT_HEIGHT.labels(addr,hname,'last_poc_challenge').set(d['last_poc_challenge'])
+    HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_current').set(d['status']['height'])
   HOTSPOT_HEIGHT.labels(addr,hname,'system').set(d['block'])
-  HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_current').set(d['status']['height'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_added').set(d['block_added'])
   #HOTSPOT_HEIGHT.labels(addr,hname,'score_update').set(d[''])
-  HOTSPOT_HEIGHT.labels(addr,hname,'last_poc_challenge').set(d['last_poc_challenge'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_last_changed').set(d['last_change_block'])
 
   now = datetime.datetime.now(datetime.timezone.utc)
@@ -191,8 +192,9 @@ def stats_for_hotspot(addr, hname):
   HOTSPOT_EXIST_EPOCH.labels(addr,hname).set(ts_delta)
 
   isup = 0
-  if d['status']['online'] == 'online':
-    isup = 1
+  if d['mode'] == 'full':
+    if d['status']['online'] == 'online':
+      isup = 1
   HOTSPOT_ONLINE.labels(addr,hname).set(isup)
 
   haz_addr = 0


### PR DESCRIPTION
If your account contains a data-only hotspot or you directly specify it with $HOTSPOT_ADDRESSES, the exporter crashes. Some attributes in the json payload are None.

`{'speculative_nonce': 1, 'lng': 15.822389020064555, 'lat': 31.166900292027595, 'timestamp_added': '2021-11-20T19:13:32.000000Z', 'status': {'timestamp': None, 'online': 'offline', 'listen_addrs': None, 'height': None}, 'reward_scale': None, 'payer': '24uWeJi3u1Z7FLY9WZ7FLYAZasdrwUjxRVu9WzxSz3Z7FLY23', 'owner': '49uWsJi3u1FjN9WWqMQjXxAZ7FLYEGgUhxRVt9WzxSf3ACqSJcW', 'nonce': 1, 'name': 'unter-ower-biesler', 'mode': 'dataonly', 'location_hex': '884f8d9a09fffff', 'location': '8c1a8e7e096e3ff', 'last_poc_challenge': None, 'last_change_block': 1213358, 'geocode': {'short_street': 'Odlgroum', 'short_state': 'BY', 'short_country': 'DE', 'short_city': 'Hinterpfuideifl', 'long_street': 'Odlgroum', 'long_state': 'Bayern', 'long_country': 'Germany', 'long_city': 'Hinterpfuideifl', 'city_id': 'bce8bmdNo9W5iY4llcm35neXJgYW55'}, 'gain': 12, 'elevation': 0, 'block_added': 1105402, 'block': 1222411, 'address': '12xmAZ7FLYEGgUmmbaf5Y1LzeiAH8ZLryX4od3j30029n1xGxpG8'}`
