### PR TITLE
Fix for issue #7

### DIFF
--- a/helium_hotspot_exporter.py
+++ b/helium_hotspot_exporter.py
@@ -84,13 +84,20 @@ def slow_stats_for_hotspot(addr, hname, d):
 def mkurl(*args):
   return API_BASE_URL + ''.join([str(x) for x in args])
 
-def req_get_json(url):
+def req_get_json(url, delay=0):
+  if delay > 5:
+    return {}
+  elif delay:
+    log.warning("wait for {}s after too frequent requests".format(delay))
   try:
+    time.sleep(delay)
     log.debug(f"fetching url: {url}")
     ret = req.get(url, headers=headers)
     log.debug(f"fetch returned: {ret}")
     if ret and ret.ok:
       return ret.json()
+    elif ret.status_code == 429:
+      return req_get_json(url, delay+0.5)
   except json.JSONDecodeError as ex:
     log.error(f"failed to get {url}, {ex}")
   return {}

--- a/helium_hotspot_exporter.py
+++ b/helium_hotspot_exporter.py
@@ -178,11 +178,12 @@ def stats_for_hotspot(addr, hname):
   # this hotspot exists.
   HOTSPOT_UP.labels(addr,hname).set(1)
 
+  if d['mode'] == 'full':
+    HOTSPOT_HEIGHT.labels(addr,hname,'last_poc_challenge').set(d['last_poc_challenge'])
+    HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_current').set(d['status']['height'])
   HOTSPOT_HEIGHT.labels(addr,hname,'system').set(d['block'])
-  HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_current').set(d['status']['height'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_added').set(d['block_added'])
   #HOTSPOT_HEIGHT.labels(addr,hname,'score_update').set(d[''])
-  HOTSPOT_HEIGHT.labels(addr,hname,'last_poc_challenge').set(d['last_poc_challenge'])
   HOTSPOT_HEIGHT.labels(addr,hname,'hotspot_last_changed').set(d['last_change_block'])
 
   now = datetime.datetime.now(datetime.timezone.utc)
@@ -191,8 +192,9 @@ def stats_for_hotspot(addr, hname):
   HOTSPOT_EXIST_EPOCH.labels(addr,hname).set(ts_delta)
 
   isup = 0
-  if d['status']['online'] == 'online':
-    isup = 1
+  if d['mode'] == 'full':
+    if d['status']['online'] == 'online':
+      isup = 1
   HOTSPOT_ONLINE.labels(addr,hname).set(isup)
 
   haz_addr = 0


### PR DESCRIPTION
The script crashes because the api rejects get-requests with 429 Too Many Requests. This patch detects this return code and retries the get after a little delay (until 5s maximum delay)